### PR TITLE
rocksdb: enable O_DIRECT for WAL files

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -265,10 +265,12 @@ static Status ValidateOptions(
         "then direct I/O reads (use_direct_reads) must be disabled. ");
   }
 
-  if (db_options.allow_mmap_writes && db_options.use_direct_writes) {
+  if (db_options.allow_mmap_writes &&
+      (db_options.use_direct_writes || db_options.use_direct_wal_writes)) {
     return Status::NotSupported(
         "If memory mapped writes (allow_mmap_writes) are enabled "
-        "then direct I/O writes (use_direct_writes) must be disabled. ");
+        "then direct I/O writes (use_direct_writes and use_direct_wal_writes) "
+	"must be disabled. ");
   }
 
   if (db_options.keep_log_file_num == 0) {

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -584,10 +584,15 @@ struct DBOptions {
   // Not supported in ROCKSDB_LITE mode!
   bool use_direct_reads = false;
 
-  // Use O_DIRECT for writing file
+  // Use O_DIRECT for writing non-WAL files
   // Default: false
   // Not supported in ROCKSDB_LITE mode!
   bool use_direct_writes = false;
+
+  // Use O_DIRECT for writing WAL files
+  // Default: false
+  // Not supported in ROCKSDB_LITE mode!
+  bool use_direct_wal_writes = false;
 
   // If false, fallocate() calls are bypassed
   bool allow_fallocate = true;

--- a/util/db_options.cc
+++ b/util/db_options.cc
@@ -54,6 +54,7 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       allow_mmap_writes(options.allow_mmap_writes),
       use_direct_reads(options.use_direct_reads),
       use_direct_writes(options.use_direct_writes),
+      use_direct_wal_writes(options.use_direct_wal_writes),
       allow_fallocate(options.allow_fallocate),
       is_fd_close_on_exec(options.is_fd_close_on_exec),
       advise_random_on_open(options.advise_random_on_open),

--- a/util/db_options.h
+++ b/util/db_options.h
@@ -49,6 +49,7 @@ struct ImmutableDBOptions {
   bool allow_mmap_writes;
   bool use_direct_reads;
   bool use_direct_writes;
+  bool use_direct_wal_writes;
   bool allow_fallocate;
   bool is_fd_close_on_exec;
   bool advise_random_on_open;

--- a/util/env.cc
+++ b/util/env.cc
@@ -316,7 +316,8 @@ void AssignEnvOptions(EnvOptions* env_options, const DBOptions& options) {
   env_options->use_mmap_reads = options.allow_mmap_reads;
   env_options->use_mmap_writes = options.allow_mmap_writes;
   env_options->use_direct_reads = options.use_direct_reads;
-  env_options->use_direct_writes = options.use_direct_writes;
+  env_options->use_direct_writes = options.use_direct_writes
+                                 | options.use_direct_wal_writes;
   env_options->set_fd_cloexec = options.is_fd_close_on_exec;
   env_options->bytes_per_sync = options.bytes_per_sync;
   env_options->compaction_readahead_size = options.compaction_readahead_size;

--- a/util/io_posix.h
+++ b/util/io_posix.h
@@ -12,6 +12,8 @@
 #include <atomic>
 #include <string>
 #include "rocksdb/env.h"
+#include <sys/param.h>   // for roundup() macro
+#include "db/log_format.h"
 
 // For non linux platform, the following macros are used only as place
 // holder.
@@ -129,6 +131,39 @@ class PosixWritableFile : public WritableFile {
 #ifdef OS_LINUX
   virtual Status RangeSync(uint64_t offset, uint64_t nbytes) override;
   virtual size_t GetUniqueId(char* id, size_t max_size) const override;
+#endif
+};
+
+class WALWritableFile : public WritableFile {
+ private:
+  static const int bufsz_ = 524288;
+ protected:
+  const std::string filename_;
+  int fd_;
+  int shm_fd_;
+  bool dirty_;
+  size_t len_;
+  off_t off_;
+  char cache_buf_[bufsz_ + 4096];
+  char *cache_;
+
+ private:
+  void ShmSetup(void);
+  void ShmTeardown(void);
+
+ public:
+  explicit WALWritableFile(const std::string& fname, int fd,
+                           const EnvOptions& options);
+  virtual ~WALWritableFile();
+
+  virtual Status Truncate(uint64_t size) override;
+  virtual Status Close() override;
+  virtual Status Append(const Slice& data) override;
+  virtual Status Sync() override;
+  virtual Status Flush() override;
+  virtual uint64_t GetFileSize() override;
+#ifdef ROCKSDB_FALLOCATE_PRESENT
+  virtual Status Allocate(uint64_t offset, uint64_t len) override;
 #endif
 };
 

--- a/util/options.cc
+++ b/util/options.cc
@@ -154,6 +154,7 @@ DBOptions::DBOptions(const Options& options)
       allow_mmap_writes(options.allow_mmap_writes),
       use_direct_reads(options.use_direct_reads),
       use_direct_writes(options.use_direct_writes),
+      use_direct_wal_writes(options.use_direct_wal_writes),
       allow_fallocate(options.allow_fallocate),
       is_fd_close_on_exec(options.is_fd_close_on_exec),
       skip_log_error_on_recovery(options.skip_log_error_on_recovery),

--- a/util/options_helper.cc
+++ b/util/options_helper.cc
@@ -74,6 +74,7 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.allow_mmap_writes = immutable_db_options.allow_mmap_writes;
   options.use_direct_reads = immutable_db_options.use_direct_reads;
   options.use_direct_writes = immutable_db_options.use_direct_writes;
+  options.use_direct_wal_writes = immutable_db_options.use_direct_wal_writes;
   options.allow_fallocate = immutable_db_options.allow_fallocate;
   options.is_fd_close_on_exec = immutable_db_options.is_fd_close_on_exec;
   options.stats_dump_period_sec = mutable_db_options.stats_dump_period_sec;


### PR DESCRIPTION
we accumulate stuff until Sync() or until we run out of room in our
currently 512k buffer.

we also stash "max written offset" for each WAL in shared mem and
then on reread, truncate the file back down to that length.  this
should ensure we don't end up with incomplete records on disk during
application crash, but all bets are off for power cut failover.

Signed-off-by: Joel Jacobson <joel.jacobson@primarydata.com>